### PR TITLE
Fix wrong argument order for curriculum agent

### DIFF
--- a/app/views/plan_view.py
+++ b/app/views/plan_view.py
@@ -6,9 +6,10 @@ def render_plan():
     if st.session_state.assessment_result and not st.session_state.plan_result:
         curriculum_agent = CurriculumAgent(os.getenv('MODEL_NAME'))
         with st.spinner("Generating your personalized 4-week learning plan..."):
+            # generate_learning_plan expects (learning_goal, assessment)
             st.session_state.plan_result = curriculum_agent.generate_learning_plan(
-                st.session_state.assessment_result,
-                st.session_state.learning_goal
+                st.session_state.learning_goal,
+                st.session_state.assessment_result
             )
 
     # --- Step 6: View Plan (Text) ---


### PR DESCRIPTION
## Summary
- fix the call to `generate_learning_plan` so learning goal is passed before the assessment

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68479c5a2e1c832b95af123cd8b35de1